### PR TITLE
Scaffold out documentation

### DIFF
--- a/server/Documentation/docs/mtdnetwork/component/host.md
+++ b/server/Documentation/docs/mtdnetwork/component/host.md
@@ -1,0 +1,5 @@
+# Host
+
+#### Description
+
+#### Dependencies

--- a/server/Documentation/docs/mtdnetwork/mtd/completetopologyshuffle.md
+++ b/server/Documentation/docs/mtdnetwork/mtd/completetopologyshuffle.md
@@ -1,0 +1,5 @@
+# Complete Topology Shuffle
+
+#### Description
+
+#### Dependencies

--- a/server/Documentation/docs/mtdnetwork/operation/attack_operation.md
+++ b/server/Documentation/docs/mtdnetwork/operation/attack_operation.md
@@ -1,0 +1,5 @@
+# Attack Operation
+
+#### Description
+
+#### Dependencies

--- a/server/Documentation/docs/mtdnetwork/statistic/evaluation.md
+++ b/server/Documentation/docs/mtdnetwork/statistic/evaluation.md
@@ -1,0 +1,5 @@
+# Evaluation
+
+#### Description
+
+#### Dependencies

--- a/server/Documentation/mkdocs.yml
+++ b/server/Documentation/mkdocs.yml
@@ -42,7 +42,16 @@ markdown_extensions:
   - attr_list
 
 nav:
- - Home: index.md
- - Code Review: codereview.md
- - Back End:
+  - Home: index.md
+  - Code Review: codereview.md
+  - Back End:
       - End points: backend/endpoints.md
+  - MTD Network Code Base:
+      - MTD:
+          - Complete Topology Shuffle: mtdnetwork/mtd/completetopologyshuffle.md
+      - Operation:
+          - Attack Operation: mtdnetwork/operation/attack_operation.md
+      - Component:
+          - Host: mtdnetwork/component/host.md
+      - Statistic:
+          - Evaluation: mtdnetwork/statistic/evaluation.md


### PR DESCRIPTION
Put in the file structure and configuration in mkdocs yml for documentation. not all files are present. the ones that are there just serve as a place holder