### PR TITLE
Mtdsim 89

### DIFF
--- a/server/mtdnetwork/mtd/__init__.py
+++ b/server/mtdnetwork/mtd/__init__.py
@@ -1,7 +1,8 @@
+'''Module for MTD class, the base class to MTD strategy subclasses'''
 from mtdnetwork.data.constants import MTD_DURATION, MTD_PRIORITY
 
-
 class MTD:
+    '''Class of generic MTD strategy'''
     def __init__(self, name: str, mtd_type: str, resource_type: str, network=None):
         """
         :param name: name of the MTD strategy
@@ -43,25 +44,33 @@ class MTD:
         )
 
     def mtd_operation(self, adversary=None):
+        '''Placeholder for mtd_operation() method defined in subclasses'''
         raise NotImplementedError
 
     def get_mtd_type(self):
+        '''Method returns mtd type'''
         return self._mtd_type
 
     def get_resource_type(self):
+        '''Method returns resource type'''
         return self._resource_type
 
     def get_name(self):
+        '''Method returns name of strategy'''
         return self._name
 
     def get_execution_time_mean(self):
+        '''Method returns mean execution time'''
         return self._execution_time_mean
 
     def get_execution_time_std(self):
+        '''Method returns standard deviation of execution time'''
         return self._execution_time_std
 
     def get_priority(self):
+        '''Method returns priority'''
         return self._priority
 
     def set_priority(self, priority):
+        '''Method assigns priority'''
         self._priority = priority

--- a/server/mtdnetwork/mtd/completetopologyshuffle.py
+++ b/server/mtdnetwork/mtd/completetopologyshuffle.py
@@ -1,10 +1,10 @@
+'''Module containing class providing mtd function to shuffle network'''
 from mtdnetwork.mtd import MTD
 
 
 class CompleteTopologyShuffle(MTD):
-    """
-    Completely regenerates the network, preserving the hosts from previously.
-    """
+    '''Completely regenerates the network, preserving the hosts from previously.'''
+
 
     def __init__(self, network=None):
         super().__init__(
@@ -15,6 +15,7 @@ class CompleteTopologyShuffle(MTD):
         )
 
     def mtd_operation(self, adversary=None):
+        '''Applies topology shuffle deference to network'''
         hosts = self.network.get_hosts()
 
         # Regenerate the network graph

--- a/server/mtdnetwork/mtd/hosttopologyshuffle.py
+++ b/server/mtdnetwork/mtd/hosttopologyshuffle.py
@@ -1,5 +1,6 @@
-from mtdnetwork.mtd import MTD
+'''Module to swap hosts within a network by altering positions of host within network structure'''
 import random
+from mtdnetwork.mtd import MTD
 
 
 class HostTopologyShuffle(MTD):
@@ -16,12 +17,14 @@ class HostTopologyShuffle(MTD):
         )
 
     def random_different_host_id(self, curr_host_id, hosts_list):
+        '''Method provides a randomly chosen host ID'''
         other_host_id = random.choice(hosts_list)
         if other_host_id == curr_host_id:
             return self.random_different_host_id(curr_host_id, hosts_list)
         return other_host_id
 
     def mtd_operation(self, adversary=None):
+        '''Method conducts the host shuffle network'''
         hosts = self.network.get_hosts()
         layer_dict = self.network.get_layers()
         cur_layer = -1

--- a/server/mtdnetwork/mtd/ipshuffle.py
+++ b/server/mtdnetwork/mtd/ipshuffle.py
@@ -1,8 +1,10 @@
+'''Module contains MTD strategy that dynamically switches IP addresses of hosts'''
 from mtdnetwork.mtd import MTD
 from mtdnetwork.component import host
 
 
 class IPShuffle(MTD):
+    '''Subclass of MTD for IP shuffle MTD strategy'''
     def __init__(self, network=None):
         super().__init__(
             name="IPShuffle",
@@ -12,6 +14,7 @@ class IPShuffle(MTD):
         )
 
     def mtd_operation(self, adversary=None):
+        '''Method shuffles hosts of network'''
         hosts = self.network.get_hosts()
 
         ip_addresses = []

--- a/server/mtdnetwork/mtd/osdiversity.py
+++ b/server/mtdnetwork/mtd/osdiversity.py
@@ -1,9 +1,10 @@
-from mtdnetwork.mtd import MTD
+'''Module to diversify operating systems in network'''
 import random
+from mtdnetwork.mtd import MTD
 from mtdnetwork.data import constants
 
-
 class OSDiversity(MTD):
+    '''Subclass to diversify operating systems in network'''
     def __init__(self, network=None):
         super().__init__(
             name="OSDiversity",

--- a/server/mtdnetwork/mtd/osdiversityassignment.py
+++ b/server/mtdnetwork/mtd/osdiversityassignment.py
@@ -1,15 +1,16 @@
+'''Module to handle OS diversity problem'''
 import random
-
+import re
+from pulp import *
+import matplotlib.pyplot as plt
 import networkx as nx
 from mtdnetwork.data.constants import OS_TYPES, OS_VERSION_DICT
-import matplotlib.pyplot as plt
 from mtdnetwork.statistic.utils import powerset, remove_element
-from pulp import *
 from mtdnetwork.mtd import MTD
-import re
 
 
 class OSDiversityAssignment(MTD):
+    '''Subclass of MTD to handle OS Diversity problem'''
     def __init__(self, network=None, os_types=OS_TYPES):
         super().__init__(
             name="OSDiversity",
@@ -23,6 +24,7 @@ class OSDiversityAssignment(MTD):
         self._checkpoint = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7]
 
     def mtd_operation(self, adversary=None):
+        '''Method assigns new operating system types and versions to each node '''
         diversity_assign = DiversityAssignment(
             graph=self.network.get_graph_copy(),
             sources=self.network.get_exposed_endpoints(),
@@ -79,6 +81,7 @@ class OSDiversityAssignment(MTD):
 
 
 class DiversityAssignment:
+    '''Supporting class to OSDiversityAssignment'''
     def __init__(self, graph, sources, dests, os_types, pos, colour_map):
         """
         MIP formulation for solving Diversity Assignment Problem
@@ -125,6 +128,7 @@ class DiversityAssignment:
         return dap_graph
 
     def draw_dap_graph(self):
+        '''Method to visualise dap graph'''
         dap_graph = self.gen_single_connection_graph()
         plt.figure(1, figsize=(15, 12))
         nx.draw(dap_graph, pos=self._pos, node_color=self._colour_map, with_labels=True)
@@ -138,7 +142,8 @@ class DiversityAssignment:
         services are compatible with certain OS Type and OS version
 
         Compromise Probability:
-            1. calculate the mean of the mean of the cvss of vulnerabilities in each service running on each OS Type.
+            1. calculate the mean of the mean of the cvss of
+            vulnerabilities in each service running on each OS Type.
             2. compromise probability = 1 / AC
 
         Variant -> OS Type
@@ -172,6 +177,7 @@ class DiversityAssignment:
         return E
 
     def objective(self):
+        '''Main class method; effectively solves OS diversity assignment'''
         # generate single connection graph
         dap_graph = self.gen_single_connection_graph()
 
@@ -293,10 +299,12 @@ class DiversityAssignment:
                     <= 0
                 )
 
-                # prob += lpSum([f[(c, a, x, i)] - (len(M) - 1) * (1 - min([s[(v, x)] for v in E.keys() for x in N]))
+                # prob += lpSum([f[(c, a, x, i)] - (len(M) - 1) * 
+                # (1 - min([s[(v, x)] for v in E.keys() for x in N]))
                 #                for x in N for i in N + M if i != x]) <= 0
                 #
-                # prob += lpSum([f[(c, a, i, x)] - (len(M) - 1) * (1 - min([s[(v, x)] for v in E.keys() for x in N]))
+                # prob += lpSum([f[(c, a, i, x)] - (len(M) - 1) * 
+                # (1 - min([s[(v, x)] for v in E.keys() for x in N]))
                 #                for x in N for i in N + M if i != x]) <= 0
 
         # Solve the problem

--- a/server/mtdnetwork/mtd/portshuffle.py
+++ b/server/mtdnetwork/mtd/portshuffle.py
@@ -1,8 +1,10 @@
+'''Module of MTD strategy that dynamically changes the ports associated with network services'''
 from mtdnetwork.mtd import MTD
 from mtdnetwork.component import host
 
 
 class PortShuffle(MTD):
+    '''Class of port shuffle strategy'''
     def __init__(self, network=None):
         super().__init__(
             name="PortShuffle",
@@ -14,7 +16,7 @@ class PortShuffle(MTD):
     def mtd_operation(self, adversary=None):
         hosts = self.network.get_hosts()
 
-        for host_id, host_instance in hosts.items():
+        for host_instance in hosts.items():
             # Do not change exposed endpoints as other organisations might
             # require to be fixed
             if host_instance.host_id in self.network.exposed_endpoints:

--- a/server/mtdnetwork/mtd/servicediversity.py
+++ b/server/mtdnetwork/mtd/servicediversity.py
@@ -1,8 +1,10 @@
-from mtdnetwork.mtd import MTD
+'''Module of MTD strategy to diversify network services'''
 import random
+from mtdnetwork.mtd import MTD
 
 
 class ServiceDiversity(MTD):
+    '''Class of diversifying network services'''
     def __init__(self, network=None, shuffles=50):
         self.shuffles = shuffles
         super().__init__(
@@ -13,6 +15,7 @@ class ServiceDiversity(MTD):
         )
 
     def mtd_operation(self, adversary=None):
+        '''Method to implement service diversity to network'''
         service_generator = self.network.get_service_generator()
         hosts = self.network.get_hosts()
         for host_id, host_instance in hosts.items():

--- a/server/mtdnetwork/mtd/usershuffle.py
+++ b/server/mtdnetwork/mtd/usershuffle.py
@@ -1,8 +1,9 @@
-from mtdnetwork.mtd import MTD
+'''Module of MTD strategy that randomly reassigns users to network hosts'''
 import random
-
+from mtdnetwork.mtd import MTD
 
 class UserShuffle(MTD):
+    '''Class to implement MTD strategy'''
     def __init__(self, network=None):
         super().__init__(
             name="UserShuffle",


### PR DESCRIPTION
- 10/10 linting complete for all mtd python files except osdiversityassignment.py
- osdiversityassignment.py contains methods that seem to use linear programming formulas - hence many 1 letter local variables such as a, c, x, V, E, M, etc. Keeping it as such seems better than renaming to fit linting snake_case standards 